### PR TITLE
Add a default style to the login widgets

### DIFF
--- a/src/components/login.js
+++ b/src/components/login.js
@@ -6,6 +6,9 @@ import React from 'react';
 import Superagent from 'superagent';
 import { WEBTASK_CLUSTER_URL, WEBTASK_VERIFICATION_PATH, WEBTASK_SMS_EMAIL_TOKEN } from 'lib/constants';
 
+import 'styles/login.less';
+
+
 export default class Login extends React.Component {
     constructor(props) {
         super(props);

--- a/src/styles/colors.less
+++ b/src/styles/colors.less
@@ -29,7 +29,7 @@
 // Inputs
 
 @input-bg-color: rgb(223, 230, 240);
-@input-fg-color: #fff;
+@input-fg-color: @text-dark-color;
 
 @input-dark-bg-color: rgb(58, 67, 81);
 @input-dark-fg-color: #fff;

--- a/src/styles/editor.less
+++ b/src/styles/editor.less
@@ -298,7 +298,7 @@
     
     & > .a0-inline-button {
         flex: 0 0 auto;
-        margin-right: 1em;
+        margin: 0 1em 0 0;
     }
 }
 

--- a/src/styles/inlineButton.less
+++ b/src/styles/inlineButton.less
@@ -26,7 +26,8 @@
     }
     
     &:focus {
-        outline: none;
+        outline: 0;
+        box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
     }
     
     .a0-set-inline-button-style(@style: @style);
@@ -62,5 +63,9 @@
     
     &.-success {
         .a0-set-inline-button-style(@style: success);
+    }
+    
+    & + .a0-inline-button {
+        margin-left: 1em;
     }
 }

--- a/src/styles/login.less
+++ b/src/styles/login.less
@@ -21,6 +21,10 @@
     padding: 0.5em;
     height: auto;
     line-height: inherit;
+    
+    textbox& {
+        resize: vertical;
+    }
 }
 
 .a0-help-block {

--- a/src/styles/login.less
+++ b/src/styles/login.less
@@ -1,0 +1,33 @@
+@import (reference) "~styles/textInput.less";
+
+.a0-login-widget, .a0-token-widget, .a0-verify-widget {
+    background-color: #F4F7FC;
+    padding: 1em;
+    color: @text-dark-color;
+}
+
+.a0-form-group {
+    label {
+        font-weight: 700;
+        margin-bottom: 5px;
+    }
+}
+
+.a0-form-control {
+    .a0-create-text-input();
+    
+    display: block;
+    width: 100%;
+    padding: 0.5em;
+    height: auto;
+    line-height: inherit;
+}
+
+.a0-help-block {
+    margin: 5px 0 10px;
+    color: lighten(@text-dark-color, 30%);
+}
+
+.a0-button-list {
+    padding-top: 1em;
+}

--- a/src/styles/textInput.less
+++ b/src/styles/textInput.less
@@ -20,12 +20,9 @@
         cursor: not-allowed;
     }
     
-    &::placeholder {
-        color: darken(@input-fg-color, 40%);
-    }
-    
     &:focus {
-        outline: none;
+        outline: 0;
+        box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
     }
     
     .a0-set-input-style(@style: @style);
@@ -35,16 +32,28 @@
     & when (@style = dark) {
         background-color: @input-dark-bg-color;
         color: @input-dark-fg-color;
+    
+        &::placeholder {
+            color: darken(@input-dark-fg-color, 40%);
+        }
     }
     
     & when (@style = darker) {
         background-color: @input-darker-bg-color;
         color: @input-darker-fg-color;
+    
+        &::placeholder {
+            color: darken(@input-darker-fg-color, 40%);
+        }
     }
     
     & when (@style = default) {
         background-color: @input-bg-color;
         color: @input-fg-color;
+    
+        &::placeholder {
+            color: lighten(@input-fg-color, 40%);
+        }
     }
 }
 


### PR DESCRIPTION
This PR tries to add (a decent) set of styles to the different login widgets (`login`, `token` and `confirm`).

Also added are some `input:focus` and `button:focus` styles borrowed from bootstrap's default theme. Otherwise, users have no visual cues as to which element has focus.