### PR TITLE
Add support for widget-level hotkeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-webtask-widget",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Embeddable webtask toolkit",
   "main": "src/webtask.js",
   "dependencies": {

--- a/src/lib/componentStack.js
+++ b/src/lib/componentStack.js
@@ -27,12 +27,12 @@ export default class ComponentStack {
         return top;
     }
     
-    push(Component, props) {
+    push(Component, props, onMounted) {
         let wrapperEl = document.createElement('div');
         
         wrapperEl.classList.add('a0-layer');
         
-        const componentRef = ReactDOM.render(<Component {...props} stack={ this } />, wrapperEl); 
+        const componentRef = ReactDOM.render(<Component {...props} stack={ this } />, wrapperEl, onMounted); 
         
         componentRef.unmount = () => {
             if (!wrapperEl) return;

--- a/src/widgets/editor.js
+++ b/src/widgets/editor.js
@@ -8,6 +8,10 @@ export default class EditorWidget extends AuthenticatedWidget {
                 save: 'onSave',
                 run: 'onRun',
             },
+            hotkeys: {
+                'Mod-Enter': e => this.run(),
+                'Mod-s': e => this.save(),
+            },
             ...options
         });
     }


### PR DESCRIPTION
Currently adds the following hotkeys, where `Mod` is `Ctrl` for Windows and `Cmd` for Mac.

**Editor**:
`Mod-s` - save
`Mod-Enter` - run

Adding additional hotkeys to other widgets is as simple as: https://github.com/auth0/webtask-widget/compare/hotkeys?expand=1#diff-5d65783f484587f03a453745d6f2e12fR11