### PR TITLE
Adds metadata support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,10 @@
 <html>
 
     <head>
+        <meta charset="utf-8">
         <title>Webtask in a box demo</title>
+        <link rel="stylesheet" href="https://cdn.auth0.com/styleguide/latest/index.css"></link>
         <script type="text/javascript" src="dist/webtask.js"></script>
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"></link>
         <style>
             * {
                 box-sizing: border-box;
@@ -55,10 +56,11 @@
                 mount: document.getElementById('cron-jobs'),
                 storeProfile: true,
             });
-
+            
             var editor = window.webtaskWidget.showEditor({
                 mount: document.getElementById('editor'),
                 storeProfile: true,
+                edit: 'test',
             });
 
             editor.on('run', function () {
@@ -68,12 +70,7 @@
             editor.on('save', function () {
                 console.log('editor.save', arguments);
             });
-
-            editor.run()
-                .then(function () {
-                    console.log('editor#run', arguments);
-                });
-
+    
 
             var logs = window.webtaskWidget.showLogs({
                 mount: document.getElementById('logs'),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-json-inspector": "^6.0.0",
     "react-object-inspector": "^0.2.0",
     "react-timeago": "^2.2.1",
-    "sandboxjs": "^2.3.1",
+    "sandboxjs": "^2.4.1",
     "superagent": "^1.4.0",
     "zeroclipboard": "^2.2.0"
   },

--- a/src/components/editor/index.js
+++ b/src/components/editor/index.js
@@ -291,7 +291,7 @@ export default class WebtaskEditor extends React.Component {
 
     inspect() {
         if (this.props.edit instanceof Sandbox.CronJob || this.props.edit instanceof Sandbox.Webtask) {
-            this.inspection$ = this.props.edit.inspect({ decrypt: true, fetch_code: true })
+            this.inspection$ = this.props.edit.inspect({ decrypt: true, fetch_code: true, meta: true })
                 .tap(this.onWebtaskInspection.bind(this));
             
             this.setState({
@@ -318,7 +318,8 @@ export default class WebtaskEditor extends React.Component {
         const onCronJob = (job) => {
             const inspectionOptions = {
                 decrypt: true,
-                fetch_code: true
+                fetch_code: true,
+                meta: true,
             };
         
             this.setState({ subject: job, meta: job.meta });
@@ -336,7 +337,8 @@ export default class WebtaskEditor extends React.Component {
         const onWebtask = (webtask) => {
             const inspectionOptions = {
                 decrypt: true,
-                fetch_code: true
+                fetch_code: true,
+                meta: true,
             };
         
             this.setState({ subject: webtask });

--- a/src/components/editor/keyValueListEditor.js
+++ b/src/components/editor/keyValueListEditor.js
@@ -4,7 +4,7 @@ import React from 'react';
 import 'styles/secretsEditor.less';
 
 
-export default class A0SecretsEditor extends React.Component {
+export default class A0KeyValueListEditor extends React.Component {
     constructor(props) {
         super(props);
 
@@ -39,24 +39,23 @@ export default class A0SecretsEditor extends React.Component {
         const state = this.state;
 
         return (
-            <div className="a0-secrets-editor">
-                <div className="a0-sidebar-intro">
-                    <h2 className="a0-title">Secrets</h2>
-                    <p className="a0-explanation">You can create webtasks that depend on a set of encrypted secrets, like an API key or connection string. To access the secret use: <code>context.secrets.KEY</code>.</p>
-                </div>
+            <div className="a0-kvlist-editor">
                 { state.secrets.map((secret, i) => (
                     secret.editing
-                        ?   <A0SecretEditor secret={ secret } key={ i }
+                        ?   <A0KeyValueEditor secret={ secret } key={ i }
                                 onAccept={ (accepted) => this.updateSecret(i, accepted) }
+                                valueType={ props.valueType }
                             />
-                        :   <A0SecretView secret={ secret } key={ i }
+                        :   <A0KeyValueViewer secret={ secret } key={ i }
                                 onEdit={ () => this.editSecret(i) }
                                 onRemove={ () => this.removeSecret(i) }
+                                valueType={ props.valueType }
                             />
                 ))}
-                <A0SecretCreator
+                <A0KeyValueCreator
                     ref="creator"
                     onAccept={ (accepted) => this.addSecret(accepted) }
+                    valueType={ props.valueType }
                 />
             </div>
         );
@@ -118,11 +117,17 @@ export default class A0SecretsEditor extends React.Component {
 }
 
 
-A0SecretsEditor.propTypes = {
+A0KeyValueListEditor.propTypes = {
     secrets: React.PropTypes.object.isRequired,
+    valueType: React.PropTypes.oneOf(['password', 'text']),
 };
 
-class A0SecretCreator extends React.Component {
+A0KeyValueListEditor.defaultProps = {
+    valueType: 'password',
+};
+
+
+class A0KeyValueCreator extends React.Component {
     constructor(props) {
         super(props);
 
@@ -150,7 +155,7 @@ class A0SecretCreator extends React.Component {
                         value={ state.key }
                     />
                     <input className="a0-text-input -dark" placeholder="Value"
-                        type="password"
+                        type={ props.valueType }
                         onChange={ (e) => this.setState({ value: e.target.value }) }
                         value={ state.value }
                     />
@@ -193,8 +198,16 @@ class A0SecretCreator extends React.Component {
     }
 }
 
+A0KeyValueCreator.propTypes = {
+    valueType: React.PropTypes.oneOf(['password', 'text']),
+};
 
-class A0SecretEditor extends React.Component {
+A0KeyValueCreator.defaultProps = {
+    valueType: 'password',
+};
+
+
+class A0KeyValueEditor extends React.Component {
     constructor(props) {
         super(props);
 
@@ -222,7 +235,7 @@ class A0SecretEditor extends React.Component {
                         value={ state.key }
                     />
                     <input className="a0-text-input -darker" placeholder="Value"
-                        type="password"
+                        type={ props.valueType }
                         onChange={ (e) => this.setState({ value: e.target.value }) }
                         value={ state.value }
                     />
@@ -258,7 +271,16 @@ class A0SecretEditor extends React.Component {
     }
 }
 
-class A0SecretView extends React.Component {
+A0KeyValueEditor.propTypes = {
+    valueType: React.PropTypes.oneOf(['password', 'text']),
+};
+
+A0KeyValueEditor.defaultProps = {
+    valueType: 'password',
+};
+
+
+class A0KeyValueViewer extends React.Component {
     constructor(props) {
         super(props);
     }
@@ -279,7 +301,7 @@ class A0SecretView extends React.Component {
                     <div className="a0-value">
                         <span className="a0-inline-text -strong -bright">Value:</span>
                         { " " }
-                        <span className="a0-inline-text -bright">********</span>
+                        <span className="a0-inline-text -bright">{ props.valueType === 'password' ? '********' : props.secret.value }</span>
                     </div>
                 </div>
                 <div className="a0-actions">
@@ -309,3 +331,11 @@ class A0SecretView extends React.Component {
         };
     }
 }
+
+A0KeyValueViewer.propTypes = {
+    valueType: React.PropTypes.oneOf(['password', 'text']),
+};
+
+A0KeyValueViewer.defaultProps = {
+    valueType: 'password',
+};

--- a/src/components/editor/paneSelector.js
+++ b/src/components/editor/paneSelector.js
@@ -1,9 +1,14 @@
 import React from 'react';
 
 export default class PaneSelector extends React.Component {
+    
     render() {
+        const className = ['a0-pane-selector'];
+        
+        if (this.props.size === 'small') className.push('-small');
+        
         return (
-            <div className="a0-pane-selector">
+            <div className={ className.join(' ') }>
                 {
                     this.props.panes.map((pane) => {
                         const classNames = ['a0-icon-button', '-icon', pane.iconClass];
@@ -17,7 +22,8 @@ export default class PaneSelector extends React.Component {
                                 className={ classNames.join(' ') }
                                 key={ pane.name }
                                 onClick={ () => this.onSelectPane(pane) }
-                            >{ pane.name }</button>
+                                title={ pane.name }
+                            ><span className="a0-selector-text">{ pane.name }</span></button>
                         );
                     })
                 }
@@ -34,4 +40,9 @@ PaneSelector.propTypes = {
     currentPane: React.PropTypes.object,
     onChange: React.PropTypes.func.isRequired,
     panes: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    size: React.PropTypes.oneOf(['small', 'large']),
+};
+
+PaneSelector.defaultProps = {
+    size: 'large',
 };

--- a/src/components/editor/panes.js
+++ b/src/components/editor/panes.js
@@ -6,8 +6,8 @@ import AceEditor from './aceEditor';
 import EditorOptions from './editorOptions';
 import HistoryItemInspector from './historyItemInspector';
 import JobHistory from './jobHistory';
+import KeyValueListEditor from './keyValueListEditor';
 import ScheduleEditor from './scheduleEditor';
-import SecretsEditor from './secretsEditor';
 
 export const CodePane = {
     hideSidebar: true,
@@ -36,6 +36,29 @@ export const HistoryPane = {
             <HistoryItemInspector
                 item={ this.state.selectedHistoryItem }
             />
+        );
+    },
+};
+
+export const MetadataPane = {
+    iconClass: '-tag',
+    id: 'meta',
+    name: 'Metadata',
+    renderBody: renderEditor,
+    renderSidebar() {
+        return (
+            <div className="a0-sidebar-metadata a0-sidebar-scroller">
+                <div className="a0-sidebar-intro">
+                    <h2 className="a0-title">Metadata</h2>
+                    <p className="a0-explanation">You can associate metadata with saved webtasks. This metadata can be used to query saved webtasks using the http api.</p>
+                </div>
+                <KeyValueListEditor
+                    ref="meta"
+                    secrets={ this.state.meta }
+                    onChange={ meta => this.onChangeMeta(meta) }
+                    valueType="text"
+                />
+            </div>
         );
     },
 };
@@ -81,11 +104,17 @@ export const SecretsPane = {
     renderBody: renderEditor,
     renderSidebar() {
         return (
-            <SecretsEditor
-                ref="secrets"
-                secrets={ this.state.secrets }
-                onChange={ secrets => this.onChangeSecrets(secrets) }
-            />
+            <div className="a0-sidebar-secrets a0-sidebar-scroller">
+                <div className="a0-sidebar-intro">
+                    <h2 className="a0-title">Secrets</h2>
+                    <p className="a0-explanation">You can create webtasks that depend on a set of encrypted secrets, like an API key or connection string. To access the secret use: <code>context.secrets.KEY</code>.</p>
+                </div>
+                <KeyValueListEditor
+                    ref="secrets"
+                    secrets={ this.state.secrets }
+                    onChange={ secrets => this.onChangeSecrets(secrets) }
+                />
+            </div>
         );
     },
 };

--- a/src/components/editor/panes.js
+++ b/src/components/editor/panes.js
@@ -50,7 +50,7 @@ export const MetadataPane = {
             <div className="a0-sidebar-metadata a0-sidebar-scroller">
                 <div className="a0-sidebar-intro">
                     <h2 className="a0-title">Metadata</h2>
-                    <p className="a0-explanation">You can associate metadata with saved webtasks. This metadata can be used to query saved webtasks using the http api.</p>
+                    <p className="a0-explanation">You can associate metadata with saved webtasks. This metadata can be used to query saved webtasks using the HTTP api.</p>
                 </div>
                 <KeyValueListEditor
                     ref="meta"

--- a/src/components/editor/strategies.js
+++ b/src/components/editor/strategies.js
@@ -5,6 +5,7 @@ import {
     CodePane,
     HistoryPane,
     LogsPane,
+    MetadataPane,
     SchedulePane,
     SecretsPane,
     SettingsPane,
@@ -33,7 +34,7 @@ export const CreateWebtaskStrategy = {
         };
     },
     onSave: saveWebtask,
-    panes: [CodePane, SecretsPane, SettingsPane, LogsPane],
+    panes: [CodePane, SecretsPane, MetadataPane, SettingsPane, LogsPane],
 };
 
 export const EditWebtaskStrategy = {
@@ -50,7 +51,7 @@ export const EditWebtaskStrategy = {
         };
     },
     onSave: saveWebtask,
-    panes: [CodePane, SecretsPane, SettingsPane, LogsPane],
+    panes: [CodePane, SecretsPane, MetadataPane, SettingsPane, LogsPane],
 };
 
 export const CreateCronJobStrategy = {
@@ -71,7 +72,7 @@ export const CreateCronJobStrategy = {
         this.setState({ jobState: state });
     },
     onSave: saveCronJob,
-    panes: [CodePane, SecretsPane, SchedulePane, LogsPane],
+    panes: [CodePane, SecretsPane, MetadataPane, SchedulePane, LogsPane],
 };
 
 export const EditCronJobStrategy = {
@@ -96,7 +97,7 @@ export const EditCronJobStrategy = {
             .finally(() => this.setState({ jobStateChangePending: false }));
     },
     onSave: saveCronJob,
-    panes: [CodePane, SecretsPane, SchedulePane, LogsPane, HistoryPane],
+    panes: [CodePane, SecretsPane, MetadataPane, SchedulePane, LogsPane, HistoryPane],
 };
 
 
@@ -112,6 +113,7 @@ function saveWebtask(nextStrategy = EditWebtaskStrategy) {
     return this.props.sandbox.create(this.state.code, {
         name: this.state.name.trim(),
         mergeBody: this.state.mergeBody,
+        meta: this.state.meta,
         parseBody: this.state.parseBody,
         secrets: this.state.secrets,
     })

--- a/src/lib/authenticatedWidget.js
+++ b/src/lib/authenticatedWidget.js
@@ -7,6 +7,8 @@ import Sandbox from 'sandboxjs';
 
 export default class AuthenticatedWidget extends Widget {
     widgetWillMount(Component, {
+        sandbox = null,
+        edit = null,
         url = 'https://webtask.it.auth0.com',
         token = null,
         container = null,
@@ -57,7 +59,6 @@ export default class AuthenticatedWidget extends Widget {
             }
             
             function handleStorageEvent(e) {
-                console.log('storage event', e);
                 if (e.storageArea === storageKey && e.newValue) {
                     try {
                         onLogin(validateProfile(JSON.stringify(e.newValue)));
@@ -114,6 +115,22 @@ export default class AuthenticatedWidget extends Widget {
             storeProfile,
             storageKey,
         };
+        
+        if (edit && edit.sandbox instanceof Sandbox) {
+            sandbox = edit.sandbox;
+        }
+        
+        if (sandbox instanceof Sandbox) {
+            this.emit('sandbox', sandbox);
+            
+            writeProfile(sandbox);
+            
+            const component = this.stack.push(Component, Object.assign({}, props, { sandbox }));
+            
+            this.widgetDidMount(component);
+            
+            return;
+        }
         
         Bluebird.resolve(readProfile(options))
             .then(validateProfile)

--- a/src/lib/componentStack.js
+++ b/src/lib/componentStack.js
@@ -32,6 +32,10 @@ export default class ComponentStack {
         
         wrapperEl.classList.add('a0-layer');
         
+        if (this.element.offsetWidth < 992) {
+            props.size = 'small';
+        }
+        
         const componentRef = ReactDOM.render(<Component {...props} stack={ this } />, wrapperEl, onMounted); 
         
         componentRef.unmount = () => {

--- a/src/styles/editor.less
+++ b/src/styles/editor.less
@@ -186,6 +186,16 @@
             }
         }
     }
+    
+    &.-small > .a0-icon-button {
+        & > .a0-selector-text {
+            display: none;
+        }
+        
+        &:before {
+            padding: 0;
+        }
+    }
 }
 
 
@@ -297,6 +307,7 @@
 
 .a0-sidebar-intro {
     margin-bottom: 1em;
+    padding: 1.5em;
 
     & > .a0-title {
         color: @text-light-color;
@@ -310,6 +321,10 @@
         font-size: 13px;
 
     }
+}
+
+.a0-sidebar-scroller {
+    overflow: auto;
 }
 
 .a0-editor-footer {

--- a/src/styles/icon.less
+++ b/src/styles/icon.less
@@ -75,6 +75,10 @@
     @content: "";
 }
 
+.a0-set-icon-content(@symbol) when (@symbol = tag) {
+    @content: "";
+}
+
 .a0-set-icon-content(@symbol) when (@symbol = trash) {
     @content: "";
 }

--- a/src/styles/iconButton.less
+++ b/src/styles/iconButton.less
@@ -134,4 +134,8 @@
     &.-split {
         .a0-set-icon(@symbol: split);
     }
+    
+    &.-tag {
+        .a0-set-icon(@symbol: tag);
+    }
 }

--- a/src/styles/jobHistory.less
+++ b/src/styles/jobHistory.less
@@ -74,6 +74,7 @@
         .a0-set-icon(@symbol: triangle-right; @rules: {
             position: absolute;
             top: 50%;
+            line-height: 1.2em;
             margin-top: -0.6em;
             left: 0.5em;
         });

--- a/src/styles/secretsEditor.less
+++ b/src/styles/secretsEditor.less
@@ -1,7 +1,7 @@
 @import "~styles/base.less";
 @import (reference) "~styles/colors.less";
 
-.a0-secrets-editor {
+.a0-kvlist-editor {
     display: flex;
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
* Introduces a metadata pane.
* Allows the pane selector buttons to collapse to icons only when the initial width of the widget is below `992px`.
* Updates `sandboxjs` to a version with better metadata support.
* Preserves metadata during editing for webtasks and cron jobs.
* Allows bootstrapping widgets with `Webtask` or `CronJob` instances.